### PR TITLE
Named tabs

### DIFF
--- a/StateHasChangedBlazor070.App/Pages/Index.cshtml
+++ b/StateHasChangedBlazor070.App/Pages/Index.cshtml
@@ -1,6 +1,6 @@
 ﻿@page "/"
 
-<TabSet bind-Selected="@SelectedTab" DefaultTab=TestType.test3>*@
+<TabSet bind-Selected="@SelectedTab" DefaultTab=TestType.test3>
     <Tab Title="First tab" Name=TestType.test1>
         <h4>First tab</h4>
         This is the first tab.

--- a/StateHasChangedBlazor070.App/Pages/Index.cshtml
+++ b/StateHasChangedBlazor070.App/Pages/Index.cshtml
@@ -1,17 +1,17 @@
 ﻿@page "/"
 
-<TabSet bind-Selected="@SelectedTab">
-    <Tab Title="First tab">
+<TabSet bind-Selected="@SelectedTab" DefaultTab=TestType.test3>*@
+    <Tab Title="First tab" Name=TestType.test1>
         <h4>First tab</h4>
         This is the first tab.
     </Tab>
 
-    <Tab Title="Second">
+    <Tab Title="Second" Name=TestType.test2>
         <h4>Second tab</h4>
         You can toggle me.
     </Tab>
 
-    <Tab Title="Third">
+    <Tab Title="Third" Name=TestType.test3>
         <h4>Third tab</h4>
 
         <label>
@@ -23,15 +23,22 @@
 <p>Change value to select at runtime</p>
 <div>
     <span>Tab Selected: </span>
-    <input type="number" bind="@SelectedTab" />
 </div>
 
 @functions
 {
-    int selectedTab = 1;
+    Enum selectedTab = TestType.test1;
+
+    public enum TestType
+    {
+      test1,
+      test2,
+      test3
+    }
+
 
     // This extra prop is a temporary fix for: https://github.com/aspnet/Blazor/issues/610
-    int SelectedTab
+    Enum SelectedTab
     {
         get => selectedTab;
         set

--- a/StateHasChangedBlazor070.Components/Tabs/ITab.cs
+++ b/StateHasChangedBlazor070.Components/Tabs/ITab.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.AspNetCore.Blazor;
+using System;
 
 namespace StateHasChangedBlazor070.Components.Tabs
 {
     public interface ITab
     {
         RenderFragment ChildContent { get; }
+        Enum Name { get; }
     }
 }

--- a/StateHasChangedBlazor070.Components/Tabs/Tab.cshtml.cs
+++ b/StateHasChangedBlazor070.Components/Tabs/Tab.cshtml.cs
@@ -11,10 +11,11 @@ namespace StateHasChangedBlazor070.Components.Tabs
 
 #pragma warning disable BL9993 // Component parameter is marked public due to ITab requirement
         [Parameter] public RenderFragment ChildContent { get; private set; }
+        [Parameter] public Enum Name { get; set; }
 #pragma warning restore BL9993 // Component parameter is marked public
 
 
-        [Parameter]         
+        [Parameter]
         /// <summary>
         /// The Tab Title
         /// </summary>

--- a/StateHasChangedBlazor070.Components/Tabs/Tab.cshtml.cs
+++ b/StateHasChangedBlazor070.Components/Tabs/Tab.cshtml.cs
@@ -15,7 +15,7 @@ namespace StateHasChangedBlazor070.Components.Tabs
 #pragma warning restore BL9993 // Component parameter is marked public
 
 
-        [Parameter]
+        [Parameter]     
         /// <summary>
         /// The Tab Title
         /// </summary>

--- a/StateHasChangedBlazor070.Components/Tabs/TabSet.cshtml.cs
+++ b/StateHasChangedBlazor070.Components/Tabs/TabSet.cshtml.cs
@@ -9,26 +9,22 @@ namespace StateHasChangedBlazor070.Components.Tabs
     {
         [Parameter] protected RenderFragment ChildContent { get; set; }
 
+        [Parameter]
         /// <summary>
         /// Sets the default tab when the component initializes.
         /// </summary>
-        int defaultTab;
+        Enum DefaultTab { get; set; }
 
         [Parameter]
         /// <summary>
         /// Gets or Sets the current tab selection.
         /// </summary>
-        protected int Selected
+        protected Enum Selected
         {
-            get => selected.GetValueOrDefault(-1);
+            get => selected ?? DefaultTab;
             set
             {
-                if (!selected.HasValue)
-                {
-                    // When an inital value is given, set the defaultTab value
-                    defaultTab = value;
-                } 
-                else if (value >= 0 && value <= tabs?.Count - 1)
+                if (tabs.ContainsKey(value))
                 {
                     SetActiveTab(tabs[value]);
                 }
@@ -39,16 +35,16 @@ namespace StateHasChangedBlazor070.Components.Tabs
         /// <summary>
         /// The Action invoked when the Selected value is changed.
         /// </summary>
-        protected Action<int> SelectedChanged { get; set; }
+        protected Action<Enum> SelectedChanged { get; set; }
 
         /// <summary>
         /// Active tab state consumed by child tab components
         /// </summary>
         public ITab ActiveTab { get; private set; }
 
-        protected int? selected;
+        protected Enum selected;
 
-        protected List<ITab> tabs = new List<ITab>();
+        protected Dictionary<Enum, ITab> tabs = new Dictionary<Enum, ITab>();
 
         /// <summary>
         /// Registers a Tab within a TabSet
@@ -56,8 +52,8 @@ namespace StateHasChangedBlazor070.Components.Tabs
         /// <param name="tab"></param>
         public void AddTab(ITab tab)
         {
-            tabs.Add(tab);
-            if (ActiveTab == null || tabs.Count - 1 == defaultTab)
+            tabs.Add(tab.Name, tab);
+            if (ActiveTab == null || DefaultTab == null || (tab.Name.ToString() == DefaultTab.ToString() && tab.Name.GetType().Name == DefaultTab.GetType().Name))
             {
                 SetActiveTab(tab);
             }
@@ -69,7 +65,7 @@ namespace StateHasChangedBlazor070.Components.Tabs
         /// <param name="tab"></param>
         public void RemoveTab(ITab tab)
         {
-            tabs.Remove(tab);
+            tabs.Remove(tab.Name);
             if (ActiveTab == tab)
             {
                 SetActiveTab(null);
@@ -82,11 +78,11 @@ namespace StateHasChangedBlazor070.Components.Tabs
         /// <param name="tab"></param>
         public void SetActiveTab(ITab tab)
         {
-            if (ActiveTab != tab)
+            if (tab != null && ActiveTab != tab)
             {
                 ActiveTab = tab;
-                selected = tabs.IndexOf(tab);
-                SelectedChanged?.Invoke(selected.Value);
+                selected = tab.Name;
+                SelectedChanged?.Invoke(selected);
                 StateHasChanged();
             }
         }


### PR DESCRIPTION
Hi EdCharbeneau,

This is my first pull request so sorry if I am doing it incorrectly. I have made changes to the code so that tabs can be named with an Enum value to make the tabs easier to work with rather than the hidden assigned integers. 

I have not recreated the input box for changing the tab selected out side of the tab component.

The DefaultTab parameter is not necessary and can be removed without issue.

I have tested by clicking around and clicking out.

Thanks
Jason 